### PR TITLE
Develop -> Main [CE-173]

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 # ORCIDLink releases
 
-Each section corresponds to a GitHub release.
+Each section corresponds to a GitHub release, other than the top "Unreleased" section which is for compiling changes between the most recent release and the next one.
 
 All changes between the most recent release and the present set of changes should be captured in the top section titled "Unreleased".
 
@@ -10,12 +10,19 @@ If the change is associated with a JIRA ticket, add the ticket number at the end
 
 ## Unreleased
 
-First release.
+DATE of release
 
-* Module created by kb-sdk init
-* Works locally, iterating on getting it to run in CI
-* migrated away from kb-sdk, removing all kb-sdk artifacts, as it will be deployed as a core service.
-* have implemented testing with 100% coverage, GHA-hosted build and push to GHCR
+SUMMARY of release
+
+* note 1 [JIRA-TICkET-1]
+* note 2 [JIRA-TICKET-2]
+
+## 0.2.0
+
+February 2, 2023
+
+On the path towards being a core service.
+
 * Migrate to mongodb
 * convert config to toml (from yaml) [CE-161]
 * convert template tech to jinja2 (from dockerize) [CE-161]
@@ -25,3 +32,14 @@ First release.
 * Add git-info task & tool to capture git [CE-164]
 * Type the ORCID API [CE-166]
 * Add commit hooks (pre-commit, pre-push) [CE-171]
+
+## 0.1.0
+
+January 20, 2023
+
+First release, prototype
+
+* Module created by kb-sdk init
+* Works locally, iterating on getting it to run in CI
+* migrated away from kb-sdk, removing all kb-sdk artifacts, as it will be deployed as a core service.
+* have implemented testing with 100% coverage, GHA-hosted build and push to GHCR

--- a/docs/operation/releasing.md
+++ b/docs/operation/releasing.md
@@ -1,0 +1,31 @@
+# Releasing
+
+The `orcidlink` service is ordinarily deployed from an image tagged with a release version. This ensures deterministic deploys, as the image for a given release will always be the same. It also enables easy reversions to a previous release, in the case of errors introduced by a release.
+
+The release process is composed of the following major tasks:
+
+
+- create a JIRA ticket for the release
+- create a new branch off of develop for the release
+- prepare codebase for release:
+  - finalize release notes
+    - rename "Unreleased" section to the version
+    - date the new release section
+    - add a description to the new release section
+    - create a new "Unreleased" section at the top
+- commit and push up these changes
+- create a PR to develop from this release branch
+  - The PR description should summarize what is in the release
+- run the manual workflow against the release branch
+- run integration tests locally using the image built for the release branch
+  - this is not yet implemented, but for now we can run the image locally, and use either direct poking like Restr in the browser, or some basic scripts (again, don't exist yet), and directly with kbase-ui
+- when/if integration tests pass, request a PR review  
+- when PR approved, merge it into develop
+- immediately create a PR from develop to main
+- get approval for this PR
+- if all goes will with PR checks (no reason they shouldn't since there should be no diff), merge it into main
+- run a final set of integration tests locally using the latest-rc image built after the merge into main
+- create a release using the GitHub release tool; the version should follow semver 2.0, and the tag should be formatted like `v#.#.#`, e.g. `v1.2.3` for release "1.2.3"
+- deploy on CI
+- exercise the API on CI
+- let devops know the release is ready for general release deployent


### PR DESCRIPTION
# CE-173 - prepare release 0.2.0

## Description

Preparing for "release" 0.2.0 - just exercising workflows, not a real release, though it will use the GH release tool.

## Issues Resolved

CE-173

* [x] Added the Jira Tickets Ids to the title of the PR
* ~~[ ] Added the Github Issue Ids to the title of the PR~~


## Testing Instructions

One needs to have bash and docker installed.

```
git clone https://github.com/kbase/kbase-service-orcidlink
cd kbase-service-orcidlink
./Taskfile test
```
  
* [x] Tests pass locally
* [x] Tests and build pass in GitHub actions
* [x] Manually verified that changes are available (if applicable)

## Dev Checklist

* [x] I have performed a self-review of my own code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] I have run the code quality tools against the codebase

## Release Notes - Development

> This section only relevant to a PR against develop

* [x] Ensure there is an "Unreleased" section located at the top of RELEASE_NOTES.md
* [x] Add relevant notes to Unreleased

## Release

> This section only relevant if this PR is preparing a release

* ~~[ ] Rename the "Unreleased" section to the appropriate release, and create a new, empty "Ureleased" section at the top~~
